### PR TITLE
Updates application callback URIs into the gitlab charm relation

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -567,6 +567,7 @@ class BaseFinosLegendCharm(charm.CharmBase):
         # if all the relations are present and write the configs itself:
         # container.autostart()
 
+        self._update_gitlab_relation_callback_uris()
         self._refresh_charm_status()
 
 
@@ -584,6 +585,9 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
         super().__init__(*args)
 
         self._set_stored_defaults()
+
+        # Standard charm lifecycle events:
+        self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
 
         # Get relation names:
         legend_db_relation_name = self._get_legend_db_relation_name()
@@ -709,6 +713,15 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
 
         return self._get_core_legend_service_configs(
             legend_db_credentials, legend_gitlab_credentials)
+
+    def _update_gitlab_relation_callback_uris(self):
+        relation = self._get_relation(self._get_legend_gitlab_relation_name())
+        redirect_uris = self._get_legend_gitlab_redirect_uris()
+        legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
+            relation.data[self.app], redirect_uris)
+
+    def _on_upgrade_charm(self, _: charm.UpgradeCharmEvent) -> None:
+        self._update_gitlab_relation_callback_uris()
 
     def _on_db_relation_joined(
             self, _: charm.RelationJoinedEvent) -> None:

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -334,6 +334,50 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
         self.assertIsInstance(
             self.harness.charm.unit.status, model.ActiveStatus)
 
+    @mock.patch("ops.testing._TestingPebbleClient.restart_services")
+    def _test_upgrade_charm(self, _container_restart_mock):
+        self.harness.set_leader()
+        self.harness.begin_with_initial_hooks()
+
+        # Setting up the gitlab relation.
+        test_data = self.harness.charm._get_relations_test_data()
+        gitlab_rel_name = self.harness.charm._get_legend_gitlab_relation_name()
+        gitlab_rel_data = test_data.pop(gitlab_rel_name)
+        gitlab_rel_id = self._add_relation(gitlab_rel_name, gitlab_rel_data)
+
+        # Add the rest of the relations.
+        for rel_name, rel_data in test_data.items():
+            self._add_relation(rel_name, rel_data)
+            self.harness.update_config()
+
+        # Assert that the unit is currently active.
+        self.assertIsInstance(
+            self.harness.charm.unit.status, model.ActiveStatus)
+
+        # Assert that the initial Callback URIs have been set.
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_uris = self.harness.charm._get_legend_gitlab_redirect_uris()
+        expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(expected_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
+
+        # Setup for the Upgrade Event.
+        fake_callback_uris = ['foo.lish']
+        mock_get_uris = self.patch(self.harness.charm, '_get_legend_gitlab_redirect_uris')
+        mock_get_uris.return_value = fake_callback_uris
+
+        # Emit the Upgrade Charm event.
+        self.harness.charm.on.upgrade_charm.emit()
+
+        # Assert that the unit is still active.
+        self.assertIsInstance(
+            self.harness.charm.unit.status, model.ActiveStatus)
+
+        # Check if the Callback URIs have been updated.
+        mock_get_uris.assert_called()
+        relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
+        expected_rel_data = {"legend-gitlab-redirect-uris": json.dumps(fake_callback_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
+
 
 class BaseFinosLegendCoreServiceTestCharm(
         legend_operator_base.BaseFinosLegendCoreServiceCharm, BaseFinosLegendTestCharm):

--- a/unit_tests/test_legend_operator_base.py
+++ b/unit_tests/test_legend_operator_base.py
@@ -220,3 +220,10 @@ class TestBaseFinosCoreServiceLegendCharm(
     def test_relations_waiting(self):
         """Tests the whole lifecycle of `legend_operator_base.BaseFinosLegendCoreServiceCharm`."""
         self._test_relations_waiting()
+
+    def test_upgrade_charm(self):
+        """Tests Upgrade handle of `legend_operator_base.BaseFinosLegendCoreServiceCharm`.
+
+        This test will ensure that the Callback URIs are being updated.
+        """
+        self._test_upgrade_charm()


### PR DESCRIPTION
When performing juju refresh, the container will get recreated with a newer juju charm version, which will mean that the container may have a different IP than it had. That means that the callback URIs written into the gitlab relation are stale, and we need to refresh that.

The same may happen any time the Kubernetes pod crashes.