### PR TITLE
Adds the external-hostname config for nginx ingress integrator

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -179,10 +179,10 @@ class BaseFinosLegendCharm(charm.CharmBase):
 
         self._set_stored_defaults()
 
-        # TODO(aznashwan): worth always setting up an ingress for all services?
+        svc_hostname = self.model.config["external-hostname"] or self.app.name
         self.ingress = ingress.IngressRequires(
             self, {
-                "service-hostname": self.app.name,
+                "service-hostname": svc_hostname,
                 "service-name": self.app.name,
                 "service-port": self._get_application_connector_port()})
 
@@ -549,6 +549,9 @@ class BaseFinosLegendCharm(charm.CharmBase):
 
     def _on_config_changed(self, event: charm.ConfigChangedEvent):
         """Refreshes the service config."""
+        # TODO(claudiub): Update the SDLC and Engine relations with the new Service URL.
+        svc_hostname = self.model.config["external-hostname"] or self.app.name
+        self.ingress.update_config({"service-hostname": svc_hostname})
         self._refresh_charm_status()
 
     def _on_workload_container_pebble_ready(

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -461,9 +461,18 @@ class TestBaseFinosCoreServiceLegendCharm(BaseFinosLegendCharmTestCase):
                 BaseFinosLegendCoreServiceTestCharm._get_workload_container_name(): {
                     "resource": "image"}},
             "resources": {"image": {"type": "oci-image"}}}
+        charm_config = {
+            "options": {
+                "external-hostname": {
+                    "type": "string",
+                    "default": "",
+                },
+            },
+        }
         harness = ops_testing.Harness(
             BaseFinosLegendCoreServiceTestCharm,
-            meta=yaml.dump(charm_meta))
+            meta=yaml.dump(charm_meta),
+            config=yaml.dump(charm_config))
         return harness
 
     def _test_get_core_legend_service_configs(self):

--- a/unit_tests/test_legend_operator_base.py
+++ b/unit_tests/test_legend_operator_base.py
@@ -162,7 +162,15 @@ class TestBaseFinosLegendCharm(legend_operator_testing.BaseFinosLegendCharmTestC
             },
             "resources": {"image": {"type": "oci-image"}},
         }
-        config = {"options": {"log-level-option": {"type": "string"}}}
+        config = {
+            "options": {
+                "external-hostname": {
+                    "type": "string",
+                    "default": "",
+                },
+                "log-level-option": {"type": "string"},
+            },
+        }
         harness = ops_testing.Harness(
             legend_operator_testing.BaseFinosLegendTestCharm,
             meta=yaml.dump(charm_meta),
@@ -210,7 +218,17 @@ class TestBaseFinosCoreServiceLegendCharm(
             "containers": {cls._get_workload_container_name(): {"resource": "image"}},
             "resources": {"image": {"type": "oci-image"}},
         }
-        harness = ops_testing.Harness(cls, meta=yaml.dump(charm_meta))
+        charm_config = {
+            "options": {
+                "external-hostname": {
+                    "type": "string",
+                    "default": "",
+                },
+            },
+        }
+        harness = ops_testing.Harness(
+            cls, meta=yaml.dump(charm_meta), config=yaml.dump(charm_config)
+        )
         return harness
 
     def test_get_core_legend_service_configs(self):


### PR DESCRIPTION
Adding this config option allows us to customize the hostname for each Legend Application, allowing us to bring our own DNS
names. For example, instead of ``http://studio_ip:8080/studio``, we can use ``http://studio.mydomain.com/studio`` instead.