### PR TITLE
Increment the finos_legend_libs LIBVERSIONs

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 TEST_CERTIFICATE_BASE64 = """


### PR DESCRIPTION
We need to increment the patch numbers before publishing them.

The new updates include:

- upgrade charm relation event handled, which will allow us to update the callback URLs into the gitlab relation.
- Kubernetes Service Patch lib usage, which will allow us to use them instead of using IPs to connect to them, or the Studio having to rely on ephemeral IPs to connect to the SDLC and Engine Applications.
- Added external-hostname config for Nginx Ingress Integrator, allowing us to bring our own DNS names.