### PR TITLE
Adds ingress routes for applications

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 TEST_CERTIFICATE_BASE64 = """
@@ -65,6 +65,10 @@ class BaseFinosLegendTestCharm(legend_operator_base.BaseFinosLegendCharm):
     @classmethod
     def _get_application_connector_port(cls):
         return 7667
+
+    @classmethod
+    def _get_ingress_routes(cls):
+        return "/legend"
 
     @classmethod
     def _get_workload_container_name(cls):


### PR DESCRIPTION
When relating to an ``nginx-ingress-integrator`` charm, a Kubernetes Ingress object is also created containing our desired information.

By default, the Kubernetes Ingress object is created with the path ``/``, which means that we won't be able to use the same hostname for ingress. Additionally, it has the annotation ``nginx.ingress.kubernetes.io/rewrite-target: /``, which means that if we would update the path to ``/legend-engine``, when accessing Legend Engine through Ingress, that ``/legend-engine`` will be
replaced by ``/``.

Using "path-routes" will allow us to configure multiple applications to have the same external hostnames, and the applications can be accessed through these ingress routes.

For example, we can configure FINOS Legend Studio, Engine, and SDLC to have the same ``external-hostname``, and they would be reached via:

```
http://finos-legend/api -> Legend SDLC
http://finos-legend/engine -> Legend Engine
http://finos-legend/ -> Legend Studio
```

In order to use multiple routes as exemplified above, we would also have to remove the ``nginx.ingress.kubernetes.io/rewrite-target`` annotation. This can be done by using the ``rewrite-enabled = False`` config option in the ``nginx-ingress-integrator`` charm.

Adds ``_get_ingress_routes`` method, which is to be implemented by the Legend SDLC, Engine, and Studio charms.