### PR TITLE
Revert "Adds tls-secret-name configuration into the IngressRequires"

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -191,8 +191,7 @@ class BaseFinosLegendCharm(charm.CharmBase):
                 # NOTE(claudiub): If this option is enabled, the requests that match the paths
                 # above would be rewritten to "rewrite-target" (/ by default), which we do not
                 # need.
-                "rewrite-enabled": False,
-                "tls-secret-name": self.model.config["tls-secret-name"]})
+                "rewrite-enabled": False})
 
         self.service_patcher = k8s_svc_patch.KubernetesServicePatch(
             self,

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 6
 
 
 TEST_CERTIFICATE_BASE64 = """
@@ -520,10 +520,6 @@ class TestBaseFinosCoreServiceLegendCharm(BaseFinosLegendCharmTestCase):
         charm_config = {
             "options": {
                 "external-hostname": {
-                    "type": "string",
-                    "default": "",
-                },
-                "tls-secret-name": {
                     "type": "string",
                     "default": "",
                 },

--- a/unit_tests/test_legend_operator_base.py
+++ b/unit_tests/test_legend_operator_base.py
@@ -168,10 +168,6 @@ class TestBaseFinosLegendCharm(legend_operator_testing.BaseFinosLegendCharmTestC
                     "type": "string",
                     "default": "",
                 },
-                "tls-secret-name": {
-                    "type": "string",
-                    "default": "",
-                },
                 "log-level-option": {"type": "string"},
             },
         }
@@ -225,10 +221,6 @@ class TestBaseFinosCoreServiceLegendCharm(
         charm_config = {
             "options": {
                 "external-hostname": {
-                    "type": "string",
-                    "default": "",
-                },
-                "tls-secret-name": {
                     "type": "string",
                     "default": "",
                 },


### PR DESCRIPTION
This reverts commit 46fc94a342af0fb92baed1d037d34a64c9365d33.

We instead went with the ``enable-tls`` config option in the charms, rather than with ``tls-secret-name``.