### PR TITLE
Fixes empty certificate parsing

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 
@@ -793,7 +793,7 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
         """Returns an `OpenSSL.X509` instance of the certificate of the related GitLab."""
         gitlab_creds = (
             self._legend_gitlab_consumer.get_legend_gitlab_creds(None))
-        if not gitlab_creds or 'gitlab_host_cert_b64' not in gitlab_creds:
+        if not gitlab_creds or not gitlab_creds.get('gitlab_host_cert_b64'):
             return None
         return parse_base64_certificate(
             gitlab_creds['gitlab_host_cert_b64'])

--- a/unit_tests/test_legend_operator_base.py
+++ b/unit_tests/test_legend_operator_base.py
@@ -249,3 +249,10 @@ class TestBaseFinosCoreServiceLegendCharm(
         This test will ensure that the Callback URIs are being updated.
         """
         self._test_upgrade_charm()
+
+    def test_get_legend_gitlab_certificate(self):
+        """Tests the _get_legend_gitlab_certificate method.
+
+        This test will ensure that the method will handle the received certificate properly.
+        """
+        self._test_get_legend_gitlab_certificate()


### PR DESCRIPTION
If the gitlab integrator charm passes in in the relation data an empty certificate, the Legend Charms will try to parse it, which will fail.

This PR addresses that issue.