### PR TITLE
Fix issue with charm units that are not leaders

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -744,6 +744,9 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
             legend_db_credentials, legend_gitlab_credentials)
 
     def _update_gitlab_relation_callback_uris(self):
+        if not self.unit.is_leader():
+            # We're not the leader, so nothing to do.
+            return
         relation = self._get_relation(self._get_legend_gitlab_relation_name())
         if not relation:
             return
@@ -781,9 +784,7 @@ class BaseFinosLegendCoreServiceCharm(BaseFinosLegendCharm):
 
     def _on_legend_gitlab_relation_joined(
             self, event: charm.RelationJoinedEvent) -> None:
-        redirect_uris = self._get_legend_gitlab_redirect_uris()
-        legend_gitlab.set_legend_gitlab_redirect_uris_in_relation_data(
-            event.relation.data[self.app], redirect_uris)
+        self._update_gitlab_relation_callback_uris()
 
     def _on_legend_gitlab_relation_changed(
             self, _: charm.RelationChangedEvent) -> None:

--- a/unit_tests/test_legend_operator_base.py
+++ b/unit_tests/test_legend_operator_base.py
@@ -243,6 +243,13 @@ class TestBaseFinosCoreServiceLegendCharm(
         """Tests Update config handle of `legend_operator_base.BaseFinosLegendCoreServiceCharm`."""
         self._test_update_config_gitlab_relation()
 
+    def test_update_config_gitlab_relation_without_being_leader(self):
+        """Tests Update config handle of `legend_operator_base.BaseFinosLegendCoreServiceCharm`.
+
+        When the unit is not a leader.
+        """
+        self._test_update_config_gitlab_relation_without_being_leader()
+
     def test_upgrade_charm(self):
         """Tests Upgrade handle of `legend_operator_base.BaseFinosLegendCoreServiceCharm`.
 


### PR DESCRIPTION
Fixes an issue when charm units that are not leaders and get `hook failed: "config-changed"`.