### PR TITLE
Allow child classes to update ingress routes if needed

### DIFF
--- a/lib/charms/finos_legend_libs/v0/legend_operator_base.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_base.py
@@ -25,7 +25,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 
@@ -579,7 +579,10 @@ class BaseFinosLegendCharm(charm.CharmBase):
     def _on_config_changed(self, event: charm.ConfigChangedEvent):
         """Refreshes the service config."""
         svc_hostname = self.model.config["external-hostname"] or self.app.name
-        self.ingress.update_config({"service-hostname": svc_hostname})
+        self.ingress.update_config({
+            "service-hostname": svc_hostname,
+            "path-routes": self._get_ingress_routes(),
+        })
         self._refresh_charm_status()
 
     def _on_workload_container_pebble_ready(

--- a/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
+++ b/lib/charms/finos_legend_libs/v0/legend_operator_testing.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 TEST_CERTIFICATE_BASE64 = """
@@ -357,6 +357,9 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
         gitlab_rel_data = test_data.pop(gitlab_rel_name)
         gitlab_rel_id = self._add_relation(gitlab_rel_name, gitlab_rel_data)
 
+        # Add the ingress relation and grab its relation ID.
+        ingress_rel_id = self._add_relation('ingress', {})
+
         # Add the rest of the necessary relations.
         for rel_name, rel_data in test_data.items():
             self._add_relation(rel_name, rel_data)
@@ -380,6 +383,13 @@ class BaseFinosLegendCharmTestCase(unittest.TestCase):
 
         relation_data = self.harness.get_relation_data(gitlab_rel_id, self.harness.charm.app)
         expected_rel_data = {'legend-gitlab-redirect-uris': json.dumps(fake_callback_uris)}
+        self.assertDictEqual(expected_rel_data, relation_data)
+
+        relation_data = self.harness.get_relation_data(ingress_rel_id, self.harness.charm.app)
+        expected_rel_data = {
+            "service-hostname": "foo.lish",
+            "path-routes": self.harness.charm._get_ingress_routes(),
+        }
         self.assertDictEqual(expected_rel_data, relation_data)
 
     @mock.patch("ops.testing._TestingPebbleClient.restart_services")


### PR DESCRIPTION
The Legend Studio application typically serves on `/studio`, however it can serve `/` as well, so a 404 Error is not encountered while accessing the root URI.

However, for the Public instance we would like to route the `/` route to the github pages, which means that we need to be able to tune what the Legend Studio charm exposes as an ingress route.